### PR TITLE
style: add line break in page title for better readability

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,7 +40,7 @@ export default function Home() {
           </div>
 
           <h1 className="text-4xl md:text-5xl font-bold mb-6 text-white">
-            Unit Kegiatan Robotika Universitas Negeri Padang
+            Unit Kegiatan Robotika <br /> Universitas Negeri Padang
           </h1>
           <p className="text-xl mb-8 text-white">MARI BERKARYA DENGAN TEKNOLOGI!!!✊🏼</p>
 


### PR DESCRIPTION
The title "Unit Kegiatan Robotika Universitas Negeri Padang" was too long and could cause layout issues on smaller screens. Adding a line break improves readability and ensures the title displays correctly across different screen sizes.